### PR TITLE
feat: add server for CCIP poc

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -1,0 +1,11 @@
+[server]
+port = 8090
+
+[starknet]
+rpc_url = "https://starknet-goerli.g.alchemy.com/v2/xxxxxx"
+private_key = "xxxxxxx"
+
+[notion]
+api_url = "https://api.notion.com/v1/pages/"
+database_id = "xxxxxx"
+secret = "xxxxxx"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,43 @@
+use serde::{self, Deserialize};
+use starknet::core::types::FieldElement;
+use std::env;
+use std::fs;
+
+pub_struct!(Clone, Deserialize; Server { port: u16 });
+
+pub_struct!(Clone, Deserialize;  Starknet {
+    rpc_url: String,
+    private_key : FieldElement,
+});
+
+pub_struct!(Clone, Deserialize;  Notion {
+    api_url: String,
+    database_id: String,
+    secret: String,
+});
+
+pub_struct!(Clone, Deserialize;  Config {
+    server: Server,
+    starknet: Starknet,
+    notion: Notion,
+});
+
+pub fn load() -> Config {
+    let args: Vec<String> = env::args().collect();
+    let config_path = if args.len() <= 1 {
+        "config.toml"
+    } else {
+        args.get(1).unwrap()
+    };
+    let file_contents = fs::read_to_string(config_path);
+    if file_contents.is_err() {
+        panic!("error: unable to read file with path \"{}\"", config_path);
+    }
+
+    match toml::from_str(file_contents.unwrap().as_str()) {
+        Ok(loaded) => loaded,
+        Err(err) => {
+            panic!("error: unable to deserialize config. {}", err);
+        }
+    }
+}

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -1,0 +1,1 @@
+pub mod resolve;

--- a/src/endpoints/resolve.rs
+++ b/src/endpoints/resolve.rs
@@ -1,0 +1,96 @@
+use crate::{
+    models::{ApiResponse, AppState, ResolveQuery},
+    utils::{get_error, hash_domain},
+};
+use axum::{
+    extract::{Query, State},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Json},
+};
+use reqwest::header::{HeaderValue, AUTHORIZATION, CONTENT_TYPE};
+use serde_json::json;
+use starknet::core::{
+    crypto::{ecdsa_sign, pedersen_hash},
+    types::FieldElement,
+};
+use starknet_id::encode;
+use std::sync::Arc;
+
+lazy_static::lazy_static! {
+    static ref FIELD_STARKNET: FieldElement = FieldElement::from_dec_str("8319381555716711796").unwrap();
+}
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<ResolveQuery>,
+) -> impl IntoResponse {
+    let url = format!(
+        "https://api.notion.com/v1/databases/{}/query",
+        state.conf.notion.database_id
+    );
+    let client = reqwest::Client::new();
+    let mut headers = HeaderMap::new();
+    headers.insert("Notion-Version", HeaderValue::from_static("2022-06-28"));
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+    let token = format!("Bearer {}", state.conf.notion.secret.clone());
+    headers.insert(AUTHORIZATION, HeaderValue::from_str(&token).unwrap());
+
+    // Create the JSON payload
+    let payload = json!({
+        "filter": {
+            "property": "Domain",
+            "title": {
+                "equals": query.domain
+            }
+        }
+    });
+
+    match client
+        .post(&url)
+        .headers(headers)
+        .json(&payload)
+        .send()
+        .await
+    {
+        Ok(response) => match response.json::<ApiResponse>().await {
+            Ok(res) => {
+                if let Some(first_result) = res.results.get(0) {
+                    if let Some(first_rich_text) = first_result.properties.Address.rich_text.get(0)
+                    {
+                        let address = &first_rich_text.plain_text;
+
+                        let domain_splitted: Vec<&str> = query.domain.split('.').collect();
+                        let encoded_domain = encode(domain_splitted[0]).unwrap();
+                        let hashed_domain = hash_domain(vec![encoded_domain]);
+
+                        let hash = pedersen_hash(
+                            &pedersen_hash(&hashed_domain, &FIELD_STARKNET),
+                            &FieldElement::from_hex_be(address).unwrap(),
+                        );
+
+                        match ecdsa_sign(&state.conf.starknet.private_key, &hash) {
+                            Ok(signature) => (
+                                StatusCode::OK,
+                                Json(
+                                    json!({"address": address, "r": signature.r, "s": signature.s}),
+                                ),
+                            )
+                                .into_response(),
+                            Err(e) => get_error(format!("Error while generating signature: {}", e)),
+                        }
+                    } else {
+                        get_error("No address found for this domain".to_string())
+                    }
+                } else {
+                    get_error("Domain not found".to_string())
+                }
+            }
+            Err(e) => get_error(format!(
+                "Error while decoding responses from Notion api: {}",
+                e
+            )),
+        },
+        Err(e) => get_error(format!("Error while fetching Notion api: {}", e)),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,46 @@
+#[macro_use]
+mod utils;
+mod config;
+mod endpoints;
+mod models;
+use axum::{http::StatusCode, routing::get, Router};
+use reqwest::Url;
+use starknet::providers::{jsonrpc::HttpTransport, JsonRpcClient};
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use tower_http::cors::{Any, CorsLayer};
+
+#[tokio::main]
+async fn main() {
+    println!("ccip_server: starting v{}", env!("CARGO_PKG_VERSION"));
+    let conf = config::load();
+
+    let shared_state = Arc::new(models::AppState {
+        conf: conf.clone(),
+        provider: JsonRpcClient::new(HttpTransport::new(
+            Url::parse(&conf.starknet.rpc_url).unwrap(),
+        )),
+    });
+
+    let cors = CorsLayer::new().allow_headers(Any).allow_origin(Any);
+    let app = Router::new()
+        .route("/", get(root))
+        .route("/resolve", get(endpoints::resolve::handler))
+        .with_state(shared_state)
+        .layer(cors);
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], conf.server.port));
+    println!("server: listening on http://0.0.0.0:{}", conf.server.port);
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service_with_connect_info::<SocketAddr>())
+        .await
+        .unwrap();
+}
+
+async fn root() -> (StatusCode, String) {
+    (
+        StatusCode::ACCEPTED,
+        format!("quest_server v{}", env!("CARGO_PKG_VERSION")),
+    )
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,0 +1,33 @@
+use serde::Deserialize;
+use starknet::providers::{jsonrpc::HttpTransport, JsonRpcClient};
+
+use crate::config::Config;
+
+pub_struct!(;AppState {
+    conf: Config,
+    provider: JsonRpcClient<HttpTransport>,
+});
+
+pub_struct!(Deserialize; ResolveQuery {
+    domain: String,
+});
+
+pub_struct!(Debug, Deserialize; ApiResponse {
+    results: Vec<ResultItem>,
+});
+
+pub_struct!(Debug, Deserialize; ResultItem {
+    properties: Properties,
+});
+
+pub_struct!(Debug, Deserialize; Properties {
+    Address: Address,
+});
+
+pub_struct!(Debug, Deserialize; Address {
+    rich_text: Vec<RichText>,
+});
+
+pub_struct!(Debug, Deserialize; RichText {
+    plain_text: String,
+});

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,69 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use starknet::core::{crypto::pedersen_hash, types::FieldElement};
+
+#[macro_export]
+macro_rules! pub_struct {
+    ($($derive:path),*; $name:ident {$($field:ident: $t:ty),* $(,)?}) => {
+        #[derive($($derive),*)]
+        pub struct $name {
+            $(pub $field: $t),*
+        }
+    }
+}
+
+pub fn get_error(error: String) -> Response {
+    (StatusCode::INTERNAL_SERVER_ERROR, error).into_response()
+}
+
+pub fn hash_domain(domain: Vec<FieldElement>) -> FieldElement {
+    if domain.is_empty() {
+        return FieldElement::ZERO;
+    }
+    let new_len = domain.len() - 1;
+    let x = domain[new_len];
+    let y = hash_domain(domain[0..new_len].to_vec());
+    pedersen_hash(&x, &y)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use starknet::core::types::FieldElement;
+
+    #[test]
+    fn test_hash_domain_empty() {
+        let domain: Vec<FieldElement> = vec![];
+        let hash: FieldElement = hash_domain(domain);
+        assert_eq!(hash, FieldElement::ZERO);
+    }
+
+    #[test]
+    fn test_hash_domain_single_element() {
+        // hash 'iris'
+        let domain: Vec<FieldElement> = vec![FieldElement::from_dec_str("999902").unwrap()];
+        let hash = hash_domain(domain);
+        let expected_hash = FieldElement::from_dec_str(
+            "2819968515778978195378012518635693386896866121180586187462905840795338238772",
+        )
+        .unwrap();
+        assert_eq!(hash, expected_hash);
+    }
+
+    #[test]
+    fn test_hash_domain_multiple_elements() {
+        // hash 'iris.notion'
+        let domain: Vec<FieldElement> = vec![
+            FieldElement::from_dec_str("999902").unwrap(),
+            FieldElement::from_dec_str("1059716045").unwrap(),
+        ];
+        let hash = hash_domain(domain);
+        let expected_hash = FieldElement::from_dec_str(
+            "743232737575968623292492568916248379498607022315110255883250117418490029830",
+        )
+        .unwrap();
+        assert_eq!(hash, expected_hash);
+    }
+}


### PR DESCRIPTION
This PR is part of https://github.com/starknet-id/naming/issues/4

It adds a server with a endpoint `resolve` that fetches the address from a Notion database given a domain name. If there is a result it will compute the signature and will return a json response with : `address`, `r` and `s`